### PR TITLE
Update commons-lang3 to 3.14.0, Add G1GC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,8 @@ repositories {
 
 dependencies {
     // Add your dependencies here
-    // Example: implementation "org.apache.commons:commons-lang3:3.13.0"
-    // You can use library "org.apache.commons:commons-lang3:3.13.0" to include the dependency in the jar file as well
+    // Example: implementation "org.apache.commons:commons-lang3:3.14.0"
+    // You can use library "org.apache.commons:commons-lang3:3.14.0" to include the dependency in the jar file as well
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Gradle Properties
-org.gradle.jvmargs=-Xmx8G
+org.gradle.jvmargs=-Xmx8G -XX:+UseG1GC
 #org.gradle.parallel=true // parallel builds are not supported by the maven central staging repository
 
 # Project Details


### PR DESCRIPTION
Even if this is disabled, Better now than never - Also we should include G1GC in case JDK 8 is ever used.