### PR TITLE
Use JDK 17 instead of 21 in terms of codespaces

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,6 +1,6 @@
-# Deploys the latest stable JDK available and sets it to default without having to manually specify it here,
+# Deploys the latest stable JDK 17 available and sets it to default without having to manually specify it here,
 # Which includes using temurin as the distribution.
 before_install:
   - curl -s "https://get.sdkman.io" | bash
   - source ~/.sdkman/bin/sdkman-init.sh
-  - sdk install java
+  - sdk install java 17.0.9-tem


### PR DESCRIPTION
Specifies JDK 17.0.9 *(temurin)* to be used instead of jitpack just fetching the actual latest it can find which is 21 since that doesn't really work well in certain repos such as this one.