### PR TITLE
Ensure the JDK is defaulted in shell

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -4,3 +4,4 @@ before_install:
   - curl -s "https://get.sdkman.io" | bash
   - source ~/.sdkman/bin/sdkman-init.sh
   - sdk install java 17.0.10-tem
+  - sdk use java 17.0.10-tem


### PR DESCRIPTION
Discovered by creeper123123321, Ensures we have the JDK defaulted for shell sessions. *(i hate sdkman lol)*