### PR TITLE
Java 21, Lower RAM usage to 4 GB max

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v2
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
           check-latest: true
       - name: Cache Dependencies
         uses: actions/cache@v4

--- a/build.gradle
+++ b/build.gradle
@@ -29,11 +29,11 @@ java {
     withJavadocJar()
 
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Gradle Properties
-org.gradle.jvmargs=-Xmx8G -XX:+UseG1GC
+org.gradle.jvmargs=-Xmx4G -XX:+UseG1GC
 #org.gradle.parallel=true // parallel builds are not supported by the maven central staging repository
 
 # Project Details

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,7 @@
-# Deploys the latest stable JDK 17 available and sets it to default without having to manually specify it here,
+# Deploys the latest stable JDK 21 available and sets it to default without having to manually specify it here,
 # Which includes using temurin as the distribution.
 before_install:
   - curl -s "https://get.sdkman.io" | bash
   - source ~/.sdkman/bin/sdkman-init.sh
-  - sdk install java 17.0.10-tem
-  - sdk use java 17.0.10-tem
+  - sdk install java 21.0.2-tem
+  - sdk use java 21.0.2-tem


### PR DESCRIPTION
1. Bumps the Java version to 21 because it is the latest LTS currently available,
2. Lowers the RAM usage to 4 GB max as 8 GB is too much and because there is a garbage collector present.