### PR TITLE
Supersed old Gradle wrapper validation step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v2
+        uses: gradle/actions/wrapper-validation@v3
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
The old repository responsible for validating the Gradle wrapper has been merged into the new Gradle/Actions repo.