### PR TITLE
JDK 21.0.4, Correct JitPack comment

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,7 @@
-# Deploys the latest stable JDK 21 available and sets it to default without having to manually specify it here,
+# Deploys the specified JDK version and sets it to default,
 # Which includes using temurin as the distribution.
 before_install:
   - curl -s "https://get.sdkman.io" | bash
   - source ~/.sdkman/bin/sdkman-init.sh
-  - sdk install java 21.0.3-tem
-  - sdk use java 21.0.3-tem
+  - sdk install java 21.0.4-tem
+  - sdk use java 21.0.4-tem


### PR DESCRIPTION
1. The JDK 21.0.4 changelogs can be found [here](https://www.oracle.com/java/technologies/javase/21-0-4-relnotes.html),
2. Corrects a comment in JitPack since the JDK in it isn't automatically updated anymore by default in this repo.