### PR TITLE
cache job -> setup-gradle job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,21 +11,14 @@ jobs:
           persist-credentials: false
       - name: Validate Gradle Wrapper
         uses: gradle/actions/wrapper-validation@v4
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 21
           check-latest: true
-      - name: Cache Dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - name: Build with Gradle
         run: ./gradlew build
       - name: Upload Artifacts to GitHub


### PR DESCRIPTION
Replaces the redundant caching system with an automated Gradle setup system instead, This was taken from the Paper repository.