### PR TITLE
Throw out the old gradle validator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v4
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Set up JDK 21


### PR DESCRIPTION
setup-gradle automatically verifies the gradle wrapper hash on it's own now.