### PR TITLE
Throw out JitPack entirely

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,0 @@
-# Deploys the specified JDK version and sets it to default,
-# Which includes using temurin as the distribution.
-before_install:
-  - curl -s "https://get.sdkman.io" | bash
-  - source ~/.sdkman/bin/sdkman-init.sh
-  - sdk install java 21.0.5-tem
-  - sdk use java 21.0.5-tem


### PR DESCRIPTION
Throws out the JitPack script from the template repo for several reasons:

1. Has to be constantly updated manually as there is no bot for it,
2. Cannot be used for multi-project builds,
3. GitHub Actions and Jenkins are already used as common CI tools and happen to be much more reliable than this one is,
4. We have maven central already implemented to most java-based projects.