### PR TITLE
Include resolutionStrategy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,11 @@ configurations {
     api.extendsFrom library
 }
 
+configurations.all {
+    resolutionStrategy.cacheDynamicVersionsFor 5, 'minutes'
+    resolutionStrategy.cacheChangingModulesFor 5, 'minutes'
+}
+
 repositories {
     mavenCentral()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,11 @@ configurations {
     api.extendsFrom library
 }
 
-configurations.all {
-    resolutionStrategy.cacheDynamicVersionsFor 5, 'minutes'
-    resolutionStrategy.cacheChangingModulesFor 5, 'minutes'
-}
+// Add to refresh local caching more often
+// configurations.all {
+//     resolutionStrategy.cacheDynamicVersionsFor 5, 'minutes'
+//     resolutionStrategy.cacheChangingModulesFor 5, 'minutes'
+// }
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Adds `resolutionStrategy` to the buildsystem, Default timer that's recommended by [AlexProgrammerDE](https://github.com/AlexProgrammerDE) is 5 minutes but can be adjusted before merge in case this is too low/high.