### PR TITLE
Switch OS image to ARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on: [pull_request, push, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Switches Ubuntu to [ARM64 variant](https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-24-image.md) - This beta image is tested and seems to work properly with the base workflow system,
However this change needs to be validated for modified workflows that depend on Docker and related.