### PR TITLE
Bump JDK to 25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,11 @@ jobs:
         with:
           cache-disabled: true
           cache-provider: basic
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 25
           check-latest: true
       - name: Build with Gradle
         run: ./gradlew build --stacktrace


### PR DESCRIPTION
Done intentionally because:

1. JDK 25 is the newest LTS that is currently available for download in terms of temurin,
2. Most ViaVersion projects now focus on this version specifically mainly because of 26.x.