### PR TITLE
Ubuntu 24.04 -> Ubuntu 26.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,9 @@ name: Build
 on: [pull_request, push, workflow_dispatch]
 permissions:
   contents: read
-
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 30
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Ubuntu 26.04 LTS was [recently released](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2604-Readme.md) along with [ARM64 variant](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2604-Arm64-Readme.md) of it.