### PR TITLE
Limit Dependabot PRs to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     cooldown:
       default-days: 7
     directory: "/"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Title says it all, Done on behalf of [kennytv's commit](https://github.com/ViaVersion/ViaVersion/commit/bb3de8ef8d9102fa6fa0cb7dded7e9276a44da86#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R9).